### PR TITLE
Remove route name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ module.exports = statful => (req, res, next) => {
         hostname: req.hostname,
         method: req.method,
         statusCode: res.statusCode,
-        route: req.route ? req.route.path : 'unknown_route',
       },
     })
   );

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -73,21 +73,18 @@ test('trigger the timer method with useful set of tags', async t => {
   t.deepEqual(statful.tags[0], {
     hostname: '127.0.0.1',
     method: 'GET',
-    route: '/user/:id',
     statusCode: 204,
   });
 
   t.deepEqual(statful.tags[1], {
     hostname: '127.0.0.1',
     method: 'GET',
-    route: 'unknown_route',
     statusCode: 404,
   });
 
   t.deepEqual(statful.tags[2], {
     hostname: '127.0.0.1',
     method: 'GET',
-    route: '*',
     statusCode: 204,
   });
 });


### PR DESCRIPTION
Since it's not possible to send certain special characters in Statful metrics, it becomes really hard to properly escape this chars.

Until a better solution appears, is easier to remove the property instead.